### PR TITLE
fix: Replace debug print with logger.debug()

### DIFF
--- a/src/bloombee/server/from_pretrained.py
+++ b/src/bloombee/server/from_pretrained.py
@@ -72,7 +72,7 @@ def load_pretrained_block(
     torch_dtype = resolve_block_dtype(config, torch_dtype)
     
     with init_empty_weights():
-        print('load_pretrained_block : init_empty_weights() ') 
+        logger.debug('load_pretrained_block: init_empty_weights()')
         block = get_model_block(config, env, policy, weight_home, path, layer_idx=block_index)
     
     block_prefix = f"{config.block_prefix}.{block_index}."


### PR DESCRIPTION
## Description
Replace print statement with proper logging framework.

## Changes
- Replace `print()` with `logger.debug()` in from_pretrained.py line 75

## Motivation
Debug output should use the logging framework for consistency and configurability. Print statements bypass logging configuration and can't be controlled by log levels.