### PR TITLE
fix: Add timeout to PyPI version check request

### DIFF
--- a/src/bloombee/utils/version.py
+++ b/src/bloombee/utils/version.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 def validate_version() -> None:
     logger.info(f"Running {TextStyle.BOLD}bloombee {bloombee.__version__}{TextStyle.RESET}")
     try:
-        r = requests.get("https://pypi.python.org/pypi/bloombee/json")
+        r = requests.get("https://pypi.python.org/pypi/bloombee/json", timeout=10)
         r.raise_for_status()
         response = r.json()
 


### PR DESCRIPTION
## Description
Add timeout to network request to prevent indefinite hanging.

## Changes  
- Add 10-second timeout to PyPI version check in version.py line 17

## Motivation
Network requests without timeouts can hang indefinitely if the remote server is unreachable. This matches the timeout pattern already used elsewhere in the codebase (reachability.py:26).