### PR TITLE
fix: Use tempfile.gettempdir() for cross-platform compatibility

### DIFF
--- a/src/bloombee/server/server.py
+++ b/src/bloombee/server/server.py
@@ -6,6 +6,7 @@ import multiprocessing as mp
 import os
 import random
 import sys
+import tempfile
 import threading
 import time
 from typing import Dict, List, Optional, Sequence, Union
@@ -280,7 +281,7 @@ class Server:
         )
 
         self.weight_home = array_1d(self.num_blocks, ValueHolder)
-        self.path = '/tmp/data/llama_weights'
+        self.path = os.path.join(tempfile.gettempdir(), 'data', 'llama_weights')
         ##############################################################
         
         # see_memory_usage("-----------------------------------------in server: after policy  ")


### PR DESCRIPTION
## Description
Fix hardcoded /tmp path for Windows and cross-platform compatibility.

## Changes
- Import tempfile module
- Replace hardcoded '/tmp/data/llama_weights' with os.path.join(tempfile.gettempdir(), 'data', 'llama_weights')

## Motivation
The hardcoded '/tmp' path doesn't exist on Windows and may not be accessible in some restricted environments. Using tempfile.gettempdir() ensures the code works across all platforms.