### PR TITLE
fix: Add port number validation

### DIFF
--- a/src/bloombee/cli/run_server.py
+++ b/src/bloombee/cli/run_server.py
@@ -173,6 +173,8 @@ def main():
     host_maddrs = args.pop("host_maddrs")
     port = args.pop("port")
     if port is not None:
+        if not (0 <= port <= 65535):
+            parser.error(f"Port must be between 0 and 65535, got {port}")
         assert host_maddrs is None, "You can't use --port and --host_maddrs at the same time"
     else:
         port = 0


### PR DESCRIPTION
## Description
Add validation for port numbers to ensure they are within valid range.

## Changes
- Validate port is between 0 and 65535 in run_server.py
- Provide clear error message for invalid ports

## Motivation
The argparse `type=int` accepts any integer, including negative numbers and values > 65535 which are invalid port numbers. Invalid ports cause confusing network errors later. This provides early validation with a clear error message.