### PR TITLE
Add batch support for speculative decoding and it's pruning

### DIFF
--- a/src/bloombee/client/inference_session.py
+++ b/src/bloombee/client/inference_session.py
@@ -146,7 +146,7 @@ class _ServerInferenceSession:
             normalize_arg(tree_attention_mask),
             normalize_arg(kv_cache_position_ids),
             normalize_arg(draft_tokens),
-            normalize_arg(torch.tensor(prefill_length)),
+            normalize_arg(prefill_length),
             normalize_arg(torch.tensor(1 if is_spec_dec else 0)),
         )
         logger.info(f"_ServerInferenceSession  step id {step_id}")
@@ -328,6 +328,7 @@ class InferenceSession:
         kv_cache_position_ids: Optional[torch.Tensor] = None,
         draft_tokens: Optional[torch.Tensor] = None,
         is_spec_decoding: Optional[torch.Tensor] = None,
+        prefill_length: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         assert not self._closed
         if torch.is_grad_enabled():
@@ -360,6 +361,7 @@ class InferenceSession:
         is_spec_decoding = is_spec_decoding.cpu() if is_spec_decoding is not None else None
         
         step_id = str(uuid.uuid4())  # Generate a unique step ID.
+        batch_size = inputs.shape[0]
 
         n_input_tokens = inputs.shape[1] if kv_cache_position_ids is None else kv_cache_position_ids.numel()
         if self._position + n_input_tokens > self._max_length:
@@ -370,13 +372,15 @@ class InferenceSession:
         server_idx = 0
         block_idx = 0
         inference_step_start = time.perf_counter()
-        self.prefill_length = inputs.shape[1] - tree_attention_mask.shape[1] if tree_attention_mask is not None and self.first_inference else 0
-        # self.first_inference = False
+        if tree_attention_mask is not None:
+            self.prefill_length = prefill_length.to(inputs.device)
+        else:
+            self.prefill_length = torch.zeros(batch_size)
         keep_indices = torch.arange(
-                inputs.shape[1],
-                dtype=torch.int64,
-                device=inputs.device
-            )
+            inputs.shape[1],
+            dtype=torch.int64,
+            device=inputs.device
+        ).unsqueeze(0).expand(inputs.shape[0], -1)
         self.keep_indices = keep_indices
         if is_spec_decoding is not None and is_spec_decoding.item() == 1:
             is_spec_dec = True
@@ -440,8 +444,11 @@ class InferenceSession:
                     time.sleep(delay) 
 
         self._position += n_input_tokens
+        # logger.info(f"keep_indices: {keep_indices}")
+        # logger.info(f"before _recover_hidden_states: {inputs}")
         if draft_tokens is not None and is_spec_dec:
-            inputs = self._recover_hidden_states(inputs, self.keep_indices, draft_tokens.shape[1])
+            inputs = self._restore_hidden_states(inputs, self.keep_indices, draft_tokens.shape[1])
+        # logger.info(f"after _recover_hidden_states: {inputs}")
         outputs = inputs 
         
         # 🔍 CLIENT DEBUG: Log inference step end
@@ -454,28 +461,48 @@ class InferenceSession:
         # print('client inference session outputs ', outputs.shape)
         return outputs
     
-    def _recover_hidden_states(self, hidden_states, keep_indices, original_length):
-        if not torch.is_tensor(keep_indices):
-            keep_indices = torch.tensor(keep_indices, device=hidden_states.device, dtype=torch.long)
-
-        if hidden_states.dim() == 2:
-            # [S_kept, H]
-            recovered = hidden_states.new_zeros((original_length, hidden_states.size(-1)))
-            recovered[keep_indices] = hidden_states
-
-        elif hidden_states.dim() == 3:
-            # [B, S_kept, H]
-            B, _, H = hidden_states.shape
-            recovered = hidden_states.new_zeros((B, original_length, H))
-            recovered[:, keep_indices, :] = hidden_states
-
-        else:
-            raise ValueError(f"Unexpected hidden_states dim {hidden_states.dim()}, expected 2 or 3")
-        mask = torch.ones(original_length, dtype=torch.bool, device=hidden_states.device)
-        mask[keep_indices] = False
-        self._last_padded_mask = mask
-
-        return recovered
+    def _restore_hidden_states(
+        self,
+        flattened_hidden_states: torch.Tensor,  # [N_total_valid, hidden_size]
+        keep_indices: torch.Tensor,  # [B, max_keep_len]，padding 为 -1
+        original_seq_len: int,  # 原始序列长度
+    ) -> torch.Tensor:
+        """
+        将铺平的 hidden states 还原为 [B, original_seq_len, hidden_size]
+        
+        Args:
+            flattened_hidden_states: [N_total_valid, hidden_size] 铺平后的有效 hidden states
+            keep_indices: [B, max_keep_len] 每个 batch 的 keep indices，padding 为 -1
+            original_seq_len: 原始序列长度
+        
+        Returns:
+            restored_hidden_states: [B, original_seq_len, hidden_size]，无效位置用 0 填充
+        """
+        batch_size, max_keep_len = keep_indices.shape
+        hidden_size = flattened_hidden_states.shape[-1]
+        device = flattened_hidden_states.device
+        dtype = flattened_hidden_states.dtype
+        
+        # 创建输出 tensor，用 0 填充
+        restored_hidden_states = torch.zeros(
+            batch_size, original_seq_len, hidden_size,
+            dtype=dtype, device=device
+        )
+        
+        # 创建有效 mask: [B, max_keep_len]
+        valid_mask = keep_indices >= 0
+        
+        # 创建 batch 索引: [B, max_keep_len]
+        batch_idx = torch.arange(batch_size, device=device).unsqueeze(1).expand_as(keep_indices)
+        
+        # 取出有效部分的索引
+        valid_batch_idx = batch_idx[valid_mask]      # [N_total_valid]
+        valid_seq_idx = keep_indices[valid_mask]     # [N_total_valid]
+        
+        # 写入还原位置
+        restored_hidden_states[valid_batch_idx, valid_seq_idx, :] = flattened_hidden_states
+        
+        return restored_hidden_states
     
     def _update_sequence(self, server_idx: int, block_idx: int, attempt_no: int) -> int:
         # If there is a failed server session, this code closes it

--- a/src/bloombee/models/llama/model.py
+++ b/src/bloombee/models/llama/model.py
@@ -88,7 +88,7 @@ class DistributedLlamaModel(FromPretrainedMixin, PTuneMixin, LlamaModel):
         # print('model.py llama model inputs_embeds, ', inputs_embeds)  # Temporarily commented for cleaner debug output
         output_shape = input_shape + (hidden_states.size(-1),)
         
-        # logger.info(f"hidden_states: {hidden_states}")
+        # logger.info(f"input_ids: {input_ids}")
 
         hidden_states = self.layers(
             hidden_states,
@@ -98,6 +98,7 @@ class DistributedLlamaModel(FromPretrainedMixin, PTuneMixin, LlamaModel):
             kv_cache_position_ids=past_key_values.kv_cache_position_ids if past_key_values is not None else None,
             draft_tokens = input_ids,
             is_spec_decoding = past_key_values.is_spec_decoding if past_key_values is not None else None,
+            prefill_length = past_key_values.prefill_length if past_key_values is not None else None,
         )
 
         if past_key_values is None:

--- a/src/bloombee/models/llama/speculative_model.py
+++ b/src/bloombee/models/llama/speculative_model.py
@@ -37,7 +37,7 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
         max_tree_depth: int = 4,
         use_kv_cache: bool = True,
         kv_cache_window: int = 2048,
-        max_new_tokens: int = 128,
+        max_new_tokens: int = 64,
         **model_kwargs,
     ) -> torch.LongTensor:
         
@@ -49,7 +49,7 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
         generation_config.return_dict_in_generate = False
 
         # Calculate session max length - this is critical for distributed inference
-        session_max_length = 2048
+        session_max_length = 4096
 
         # Use inference session for proper distributed caching
         with self.transformer.h.inference_session(max_length=session_max_length) as session:
@@ -93,23 +93,45 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
         
         # Initialize past_key_values for session tracking
         past_key_values = RemotePastKeyValues()
-        past_key_values.update_seen(session.position)
+        batch_positions = torch.full(
+            (batch_size,), 
+            session.position,
+            dtype=torch.long,
+            device="cuda"
+        )
+        past_key_values.update_seen(batch_positions)
         past_key_values.set_is_spec_decoding(torch.tensor([1], dtype=torch.long, device="cuda"))
         
         is_first_iteration = True
         step_idx = 0
         current_input_ids = input_ids
-        result = ""
         llm_generated_token = None
         
-        while not finished and current_input_ids.shape[1] < input_ids.shape[1] + max_new_tokens:
-            # 1. Build speculative trees using SSM
+        # 新增：维护每个序列的真实长度
+        seq_lengths = torch.full((batch_size,), input_ids.shape[1], dtype=torch.long, device=input_ids.device)
+        ignore_token_ids: list = [0, 2]
+        valid_mask = torch.ones_like(input_ids, dtype=torch.bool)
+        for token_id in ignore_token_ids:
+            valid_mask = valid_mask & (input_ids != token_id)
+        
+        # 计算每个序列的有效 token 数量
+        seq_lengths = valid_mask.sum(dim=1)  # [batch_size]
+        past_key_values.set_prefill_length(seq_lengths)
+        
+        pad_token_id = generation_config.pad_token_id if generation_config.pad_token_id is not None else 0
+        logger.info(f"init input_ids: {input_ids}, seq_lengths: {seq_lengths}")
+        # 修改循环条件：基于最短序列的长度判断
+        initial_len = input_ids.shape[1]
+        while not finished and (seq_lengths.min().item() - initial_len) < max_new_tokens:
+            # 1. Build speculative trees using SSM - 传入 seq_lengths
             spec_trees = self._build_speculative_trees_batched(
-                current_input_ids, ssm, beam_width, max_tree_depth
+                current_input_ids, ssm, beam_width, max_tree_depth, seq_lengths
             )
             
-            # 2. Verify trees using distributed inference - but through forward() call
-            verified_tokens, verified_tokens_positions, past_key_values, llm_generated_token = self._verify_trees_with_forward(
+            # logger.info(f"spec_trees, {spec_trees}")
+            
+            # 2. Verify trees using distributed inference
+            verified_tokens, verified_tokens_positions, past_key_values, llm_generated_token, valid_lengths = self._verify_trees_with_forward(
                 input_ids=current_input_ids,
                 llm_generated_token=llm_generated_token,
                 trees=spec_trees,
@@ -117,8 +139,11 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
                 past_key_values=past_key_values,
                 is_first_iteration=is_first_iteration,
                 use_kv_cache=use_kv_cache,
-                kv_cache_window=kv_cache_window
+                kv_cache_window=kv_cache_window,
+                seq_lengths=seq_lengths,
             )
+            
+            # logger.info(f"verified_tokens_positions: {verified_tokens_positions}")
             
             past_key_values.set_kv_cache(verified_tokens_positions)
             
@@ -126,19 +151,38 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
             
             # 3. Apply stopping conditions
             if has_eos_stopping_criteria:
-                verified_tokens = verified_tokens * unfinished_sequences + generation_config.pad_token_id * (
-                    1 - unfinished_sequences
+                if verified_tokens is not None:
+                    verified_tokens = verified_tokens * unfinished_sequences.unsqueeze(-1) + pad_token_id * (
+                        1 - unfinished_sequences.unsqueeze(-1)
+                    )
+                llm_generated_token = llm_generated_token * unfinished_sequences.unsqueeze(-1) + pad_token_id * (
+                    1 - unfinished_sequences.unsqueeze(-1)
                 )
 
-            # 4. Update input sequence
-            if verified_tokens is not None:
-                current_input_ids = torch.cat([current_input_ids, verified_tokens], dim=-1)
-                current_input_ids = torch.cat([current_input_ids, llm_generated_token.unsqueeze(0)], dim=-1)
+            # 4. Update input sequence with proper padding handling
+            # logger.info(f"current_input_ids: {current_input_ids}")
+            # logger.info(f"verified_tokens: {verified_tokens}")
+            # logger.info(f"llm_generated_token: {llm_generated_token}")
+            # logger.info(f"valid_lengths: {valid_lengths}")
+            # logger.info(f"seq_lengths: {seq_lengths}")
+            current_input_ids, seq_lengths = self._update_input_ids_with_padding(
+                current_input_ids=current_input_ids,
+                verified_tokens=verified_tokens,
+                llm_generated_token=llm_generated_token,
+                valid_lengths=valid_lengths,
+                seq_lengths=seq_lengths,
+                pad_token_id=pad_token_id,
+            )
+            
+            # logger.info(f"current_input_ids: {current_input_ids}, seq_lengths: {seq_lengths}")
 
-                if streamer is not None:
-                    streamer.put(verified_tokens.cpu())
-            else :
-                current_input_ids = torch.cat([current_input_ids, llm_generated_token.unsqueeze(0)], dim=-1)
+            if streamer is not None:
+                # Stream 时根据 valid_lengths 只输出有效 token
+                for i in range(batch_size):
+                    if unfinished_sequences[i]:
+                        if verified_tokens is not None and valid_lengths[i] > 0:
+                            streamer.put(verified_tokens[i, :valid_lengths[i]].cpu())
+                        streamer.put(llm_generated_token[i].cpu())
 
             # 5. Check if finished
             unfinished_sequences = unfinished_sequences & ~stopping_criteria(current_input_ids, None)
@@ -147,7 +191,61 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
 
         if streamer is not None:
             streamer.end()
+        
         return current_input_ids
+
+    def _update_input_ids_with_padding(
+        self,
+        current_input_ids: torch.LongTensor,
+        verified_tokens: Optional[torch.LongTensor],
+        llm_generated_token: torch.LongTensor,
+        valid_lengths: torch.LongTensor,
+        seq_lengths: torch.LongTensor,
+        pad_token_id: int,
+    ) -> Tuple[torch.LongTensor, torch.LongTensor]:
+        """
+        更新 input_ids，处理不同序列验证通过的 token 数量不同的情况
+        
+        Returns:
+            updated_input_ids: 更新后的 input_ids，padding 对齐
+            updated_seq_lengths: 更新后的每个序列真实长度
+        """
+        batch_size = current_input_ids.shape[0]
+        device = current_input_ids.device
+        
+        # 计算每个序列需要添加的 token 数（verified + 1 个 llm token）
+        tokens_to_add = valid_lengths + 1  # [batch_size]
+        
+        # 计算新的序列长度
+        new_seq_lengths = seq_lengths + tokens_to_add
+        new_max_len = new_seq_lengths.max().item()
+        
+        # 创建新的 input_ids tensor
+        new_input_ids = torch.full(
+            (batch_size, new_max_len), 
+            pad_token_id, 
+            dtype=torch.long, 
+            device=device
+        )
+        
+        for i in range(batch_size):
+            old_len = seq_lengths[i].item()
+            new_len = new_seq_lengths[i].item()
+            
+            # 复制原有的有效 token
+            new_input_ids[i, :old_len] = current_input_ids[i, :old_len]
+            
+            # 添加验证通过的 token
+            v_len = valid_lengths[i].item()
+            if v_len > 0 and verified_tokens is not None:
+                new_input_ids[i, old_len:old_len + v_len] = verified_tokens[i, :v_len]
+                # 添加 llm_generated_token
+                new_input_ids[i, old_len + v_len] = llm_generated_token[i, 0]
+            else:
+                # 只添加 llm_generated_token
+                new_input_ids[i, old_len] = llm_generated_token[i, 0]
+        
+        return new_input_ids, new_seq_lengths
     
     def _verify_trees_with_forward(
         self,
@@ -159,20 +257,37 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
         is_first_iteration: bool,
         use_kv_cache: bool,
         kv_cache_window: int,
-    ) -> Tuple[torch.LongTensor, torch.Tensor, RemotePastKeyValues, torch.Tensor]:
+        seq_lengths: torch.LongTensor,
+    ) -> Tuple[torch.LongTensor, torch.Tensor, RemotePastKeyValues, torch.Tensor, torch.Tensor]:
         """
         Verify speculative trees using standard forward() call within the active session context
+        
+        Returns:
+            verified_tokens: [batch_size, max_verified_len] 或 None
+            kv_cache_position_ids: [batch_size, max_pos_len]
+            past_key_values: 更新后的 past_key_values
+            llm_generated_tokens: [batch_size, 1]
+            valid_lengths: [batch_size] 每个序列验证通过的 token 数
         """
         
         tree_tokens, attention_mask, batch_node_paths = prepare_incremental_tree_batch(
-            trees, input_ids, input_ids.device
+            trees, input_ids, input_ids.device, seq_lengths=seq_lengths
         )
+        
+        # logger.info(f"tree_tokens: {tree_tokens}, attention_mask: {attention_mask.shape}")
+        
+        batch_size = input_ids.shape[0]
+        device = input_ids.device
         
         if attention_mask is None or tree_tokens.shape[1] == 0:
             logger.warning("No tree tokens to verify, falling back to regular generation")
-            return self._fallback_generation_with_forward(input_ids, logits_processor, past_key_values), past_key_values
+            fallback_token = self._fallback_generation_with_forward(input_ids, logits_processor, past_key_values, seq_lengths)
+            valid_lengths = torch.zeros(batch_size, dtype=torch.long, device=device)
+            return None, torch.zeros(batch_size, 1, dtype=torch.long, device=device), past_key_values, fallback_token, valid_lengths
         
         tree_mask_packed = self.pack_bool_mask_to_int64(attention_mask)
+        
+        # logger.info(f"tree_mask_packed: {tree_mask_packed}")
         
         with torch.no_grad():
             if not use_kv_cache:
@@ -189,26 +304,23 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
                 
             elif is_first_iteration or past_key_values is None:
                 # First iteration: process full sequence to establish cache
-                full_sequence = torch.cat([input_ids, tree_tokens], dim=-1)
+                # 需要根据 seq_lengths 构建正确的 full_sequence
+                max_seq_len = seq_lengths.max().item()
+                full_sequence = torch.cat([input_ids[:, :max_seq_len], tree_tokens], dim=-1)
+                
                 outputs = self(
                     input_ids=full_sequence,
-                    attention_mask=tree_mask_packed,  # Let the session handle attention
-                    past_key_values=past_key_values,  # Start fresh
+                    attention_mask=tree_mask_packed,
+                    past_key_values=past_key_values,
                     use_cache=True
                 )
                 
-                # Extract only the tree portion of the logits
                 logits = outputs.logits
                 
-                # Update past_key_values tracking
                 if past_key_values is None:
                     new_past_key_values = RemotePastKeyValues()
                 else:
                     new_past_key_values = past_key_values
-                
-                # The session will automatically handle the KV cache positioning
-                # if self.transformer.h.active_session:
-                #     new_past_key_values.update_seen(self.transformer.h.active_session.position)
                 
             else:
                 # Subsequent iterations: use existing cache
@@ -220,12 +332,12 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
                 if active_session.position > kv_cache_window:
                     trim_amount = active_session.position - kv_cache_window
                     active_session.position = kv_cache_window
+                    
                 if llm_generated_token is None:
                     full_sequence = tree_tokens
                 else:
-                    full_sequence = torch.cat([llm_generated_token.unsqueeze(0), tree_tokens], dim=-1)
+                    full_sequence = torch.cat([llm_generated_token, tree_tokens], dim=-1)
                 
-                # Process tree tokens with existing cache
                 outputs = self(
                     input_ids=full_sequence,
                     attention_mask=tree_mask_packed,
@@ -237,11 +349,11 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
                 new_past_key_values = past_key_values
                 new_past_key_values.update_seen(active_session.position)
                 
-        # Extract verification results
-        verified_tokens, verified_tokens_positions, llm_generated_token = self._extract_best_verified_paths_fixed(
-            logits, batch_node_paths, input_ids, logits_processor, tree_tokens.shape[1]
+        # Extract verification results - 现在返回 valid_lengths
+        verified_tokens, kv_cache_position_ids, llm_generated_tokens, valid_lengths = self._extract_best_verified_paths_fixed(
+            logits, batch_node_paths, input_ids, logits_processor, tree_tokens.shape[1], seq_lengths, is_first_iteration
         )
-        return verified_tokens, verified_tokens_positions, new_past_key_values, llm_generated_token
+        return verified_tokens, kv_cache_position_ids, new_past_key_values, llm_generated_tokens, valid_lengths
     
     def pack_bool_mask_to_int64(self, mask_bool: torch.Tensor) -> torch.Tensor:
         assert mask_bool.dtype == torch.bool, "Input must be a bool tensor"
@@ -252,6 +364,7 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
         input_ids: torch.LongTensor, 
         logits_processor: LogitsProcessorList,
         past_key_values: RemotePastKeyValues,
+        seq_lengths: torch.LongTensor,
         temperature: float = 1.0
     ) -> torch.LongTensor:
         """
@@ -260,15 +373,23 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
         try:
             logger.info("[DEBUG] Using fallback generation")
             
-            # Generate single token using standard forward call
+            batch_size = input_ids.shape[0]
+            device = input_ids.device
+            
+            # 获取每个序列最后一个有效 token
+            last_tokens = torch.zeros(batch_size, 1, dtype=torch.long, device=device)
+            for i in range(batch_size):
+                last_pos = seq_lengths[i].item() - 1
+                last_tokens[i, 0] = input_ids[i, last_pos]
+            
             outputs = self(
-                input_ids=input_ids[:, -1:],  # Just the last token
+                input_ids=last_tokens,
                 attention_mask=None,
                 past_key_values=past_key_values,
                 use_cache=True
             )
             
-            logits = outputs.logits[:, -1, :]  # Last position logits
+            logits = outputs.logits[:, -1, :]  # [batch_size, vocab_size]
             
             # Apply logits processors
             processed_logits = logits
@@ -286,30 +407,34 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
             
         except Exception as e:
             logger.error(f"Fallback generation failed: {e}")
-            # Ultimate fallback - return EOS token
             eos_token_id = getattr(self.config, 'eos_token_id', 2)
-            return torch.tensor([[eos_token_id]], device=input_ids.device)
+            return torch.full((input_ids.shape[0], 1), eos_token_id, device=input_ids.device)
     
-    # Keep your existing methods with minimal changes
     def _build_speculative_trees_batched(
         self, 
         input_ids: torch.LongTensor, 
         ssm: LlamaForCausalLM, 
         beam_width: int, 
-        max_depth: int
+        max_depth: int,
+        seq_lengths: torch.LongTensor,
     ) -> List[SpeculativeTree]:
         """Build speculative trees using the small model (SSM)"""
-        # start_total = time.time()
         batch_size = input_ids.shape[0]
         trees = []
+        
+        pad_token_id = getattr(ssm.config, 'pad_token_id', 0)
 
         for batch_idx in range(batch_size):
-            # start_batch = time.time()
-            root_token = input_ids[batch_idx, -1].item()
+            # 获取该序列的真实长度
+            actual_len = seq_lengths[batch_idx].item()
+            
+            # 只取有效部分的 input_ids
+            valid_input_ids = input_ids[batch_idx, :actual_len]
+            
+            root_token = valid_input_ids[-1].item()
             tree = SpeculativeTree(root_token, f"req_{batch_idx}")
+            
             for depth in range(max_depth):
-                # start_depth = time.time()
-
                 current_nodes = tree.get_nodes_at_depth(depth)
                 if not current_nodes:
                     break
@@ -319,7 +444,7 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
                 for node in current_nodes:
                     path_to_node = node.get_path_from_root()
                     context = torch.cat([
-                        input_ids[batch_idx, :-1],
+                        valid_input_ids[:-1],  # 使用有效的 input_ids
                         torch.tensor([root_token] + path_to_node, device=input_ids.device)
                     ])
                     contexts.append(context)
@@ -333,16 +458,16 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
 
                 for ctx in contexts:
                     pad_len = max_len - len(ctx)
-                    pad_token_id = getattr(ssm.config, 'pad_token_id', 0)
 
+                    # 左侧 padding
                     padded = torch.cat([
                         torch.full((pad_len,), pad_token_id, dtype=torch.long, device=input_ids.device),
                         ctx
                     ])
 
                     mask = torch.cat([
-                        torch.zeros(pad_len, dtype=torch.bool, device=input_ids.device),
-                        torch.ones(len(ctx), dtype=torch.bool, device=input_ids.device)
+                        torch.zeros(pad_len, dtype=torch.long, device=input_ids.device),
+                        torch.ones(len(ctx), dtype=torch.long, device=input_ids.device)
                     ])
 
                     padded_contexts.append(padded)
@@ -352,14 +477,13 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
                 batch_masks = torch.stack(attention_masks)
 
                 # SSM forward
-                # start_ssm = time.time()
                 with torch.no_grad():
-                    outputs = ssm(batch_contexts, attention_mask=batch_masks)
-                    batch_logits = outputs.logits[:, -1, :]
-                # end_ssm = time.time()
+                    # logger.info(f"batch_contexts: {batch_contexts}")
+                    # logger.info(f"batch_masks: {batch_masks}")
+                    outputs = ssm(batch_contexts, attention_mask=batch_masks, use_cache=False)
+                    batch_logits = outputs.logits[:, -1, :]  # 左侧 padding 所以 -1 是正确的
 
                 # Generate candidates
-                # start_add_layer = time.time()
                 candidates_per_node = []
                 for i in range(len(current_nodes)):
                     logits = batch_logits[i]
@@ -391,71 +515,143 @@ class DistributedLlamaForSpeculativeGeneration(DistributedLlamaForCausalLM):
         batch_node_paths: List[List[List[TreeNode]]],
         input_ids: torch.LongTensor,
         logits_processor: LogitsProcessorList,
-        tree_len: int # do not include root
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tree_len: int,
+        seq_lengths: torch.LongTensor,
+        is_first_iteration: bool,
+    ) -> Tuple[Optional[torch.Tensor], torch.Tensor, torch.Tensor, torch.Tensor]:
         """
-        Extract best verified paths (simplified for batch=1)
-        Returns: (verified_tokens, kv_cache_position_ids)
+        Returns:
+            verified_tokens: [batch_size, max_verified_len] 或 None
+            kv_cache_position_ids: [batch_size, max_pos_len]
+            llm_generated_tokens: [batch_size, 1]
+            valid_lengths: [batch_size] 每个序列验证通过的 token 数（不包括 llm token）
         """
+        batch_size = logits.shape[0]
+        seq_len = logits.shape[1]
         total_tree_tokens = tree_len
-        fallback_pos = max(0, logits.shape[1] - total_tree_tokens)
-        tree_root_position = input_ids.shape[1] - 1
-
-        node_paths = batch_node_paths[0]
-        best_verified = []
-        best_positions = []
-        best_score = -1
-        for node_path in node_paths:
-            verified_tokens = []
-            verified_positions = []
-            for node in node_path:
-                pos = node.parent.position_in_sequence + 1
-                if pos >= logits.shape[1]:
-                    break
-                
-                predicted_token = torch.argmax(logits[0, pos]).item()
-                
-                current_logits = logits[0, node.position_in_sequence + 1]
-                
-                if (torch.all(current_logits == 0)):
-                    break
-                
-                if predicted_token == node.token_id:
-                    verified_tokens.append(node.token_id)
-                    absolute_position = tree_root_position + node.position_in_sequence + 1
-                    verified_positions.append(absolute_position)
-                else:
-                    break
+        fallback_pos = max(0, seq_len - total_tree_tokens)
+        device = logits.device
+        
+        # 存储结果
+        verified_tokens_list = []
+        positions_list = []
+        llm_tokens_list = []
+        valid_lengths_list = []
+        
+        for batch_idx in range(batch_size):
+            actual_len = seq_lengths[batch_idx].item()
+            real_fallback_pos = actual_len if is_first_iteration else fallback_pos
+            tree_root_position = actual_len - 1
             
-            if len(verified_tokens) > best_score:
-                best_score = len(verified_tokens)
-                best_verified = verified_tokens
-                best_positions = verified_positions
+            node_paths = batch_node_paths[batch_idx]
+            best_verified = []
+            best_positions = []
+            best_score = -1
+            
+            for node_path in node_paths:
+                verified_tokens = []
+                verified_positions = []
                 
-        if len(best_verified) == 0:
-            final_logits = logits[0, fallback_pos-1:fallback_pos]  # 取单个位置的logits
-            processed_logits = final_logits
-            for processor in logits_processor:
-                processed_logits = processor(input_ids, processed_logits)
+                for node in node_path:
+                    pos = node.parent.position_in_sequence + 1
+                    if pos >= seq_len:
+                        break
+                    
+                    predicted_token = torch.argmax(logits[batch_idx, pos]).item()
+                    
+                    if predicted_token == node.token_id:
+                        verified_tokens.append(node.token_id)
+                        absolute_position = tree_root_position + node.position_in_sequence + 1
+                        verified_positions.append(absolute_position)
+                    else:
+                        break
                 
-            top5_values, top5_indices = torch.topk(final_logits[0], k=5)
-            next_token = torch.argmax(final_logits[0]).item()
-            kv_cache_position_ids = torch.tensor([tree_root_position], 
-                                            device=logits.device)
-            llm_generated_token = torch.tensor([next_token], device=logits.device)
-            return None, kv_cache_position_ids, llm_generated_token
+                if len(verified_tokens) > best_score:
+                    best_score = len(verified_tokens)
+                    best_verified = verified_tokens
+                    best_positions = verified_positions
+            
+            # 确定取 llm_token 的位置
+            if len(best_verified) > 0:
+                pos = best_positions[-1] - tree_root_position
+                final_logits = logits[batch_idx, pos].unsqueeze(0)
+                
+                # 检查是否全 0（被裁剪），需要回退
+                if torch.all(final_logits == 0):
+                    # 回退：最后一个 verified token 作为 llm_token
+                    llm_token = torch.tensor([best_verified[-1]], device=device)
+                    best_verified = best_verified[:-1]
+                    best_positions = best_positions[:-1]
+                else:
+                    # 正常：从 logits 采样
+                    processed_logits = final_logits.clone()
+                    for processor in logits_processor:
+                        processed_logits = processor(
+                            input_ids[batch_idx:batch_idx+1],
+                            processed_logits
+                        )
+                    next_token = torch.argmax(processed_logits[0]).item()
+                    llm_token = torch.tensor([next_token], device=device)
+            else:
+                # fallback: 从 fallback_pos 采样
+                final_logits = logits[batch_idx, real_fallback_pos - 1:real_fallback_pos]
+                processed_logits = final_logits.clone()
+                for processor in logits_processor:
+                    processed_logits = processor(
+                        input_ids[batch_idx:batch_idx+1],
+                        processed_logits
+                    )
+                next_token = torch.argmax(processed_logits[0]).item()
+                llm_token = torch.tensor([next_token], device=device)
+            
+            # 构建 positions
+            all_positions = [tree_root_position] + best_positions
+            positions = torch.tensor(all_positions, device=device)
+            
+            # 构建 verified_tensor
+            if len(best_verified) > 0:
+                verified_tensor = torch.tensor(best_verified, dtype=torch.long, device=device)
+            else:
+                verified_tensor = torch.empty(0, dtype=torch.long, device=device)
+            
+            verified_tokens_list.append(verified_tensor)
+            positions_list.append(positions)
+            llm_tokens_list.append(llm_token)
+            valid_lengths_list.append(len(best_verified))
         
-        verified_tensor = torch.tensor([best_verified], device=logits.device)  # [1, num_verified]
-        pos = best_positions[-1] - tree_root_position
-        final_logits = logits[0, pos]  # 取单个位置的logits
+        # 统一 padding 成 batch tensor
         
-        processed_logits = final_logits
-        for processor in logits_processor:
-            processed_logits = processor(input_ids, processed_logits)
-        next_token = torch.argmax(final_logits).item()
-        llm_generated_token = torch.tensor([next_token], device=logits.device)
+        # 1. llm_generated_tokens: [batch_size, 1]
+        llm_generated_tokens = torch.stack(llm_tokens_list, dim=0)
         
-        all_positions = [tree_root_position] + best_positions
-        kv_cache_position_ids = torch.tensor(all_positions, device=logits.device)
-
-        return verified_tensor, kv_cache_position_ids, llm_generated_token
+        # 2. valid_lengths: [batch_size]
+        valid_lengths = torch.tensor(valid_lengths_list, dtype=torch.long, device=device)
+        
+        # 3. positions: [batch_size, max_pos_len]
+        max_pos_len = max(pos.shape[0] for pos in positions_list)
+        kv_cache_position_ids = torch.full(
+            (batch_size, max_pos_len),
+            -1,
+            dtype=torch.long,
+            device=device
+        )
+        for i, pos in enumerate(positions_list):
+            kv_cache_position_ids[i, :pos.shape[0]] = pos
+        
+        # 4. verified_tokens: [batch_size, max_verified_len] 或 None
+        max_verified_len = max(v.shape[0] for v in verified_tokens_list) if verified_tokens_list else 0
+        
+        if max_verified_len > 0:
+            verified_tokens = torch.full(
+                (batch_size, max_verified_len),
+                -1,
+                dtype=torch.long,
+                device=device
+            )
+            for i, v in enumerate(verified_tokens_list):
+                if v.shape[0] > 0:
+                    verified_tokens[i, :v.shape[0]] = v
+        else:
+            verified_tokens = None
+        
+        return verified_tokens, kv_cache_position_ids, llm_generated_tokens, valid_lengths

--- a/src/bloombee/server/server.py
+++ b/src/bloombee/server/server.py
@@ -237,7 +237,7 @@ class Server:
         if max_batch_size is None:
             max_batch_size = 8192 if is_multiquery_attn else 2048
         if inference_max_length is None:
-            inference_max_length = 8192 if is_multiquery_attn else 2048
+            inference_max_length = 8192 if is_multiquery_attn else 4096
         self.min_batch_size, self.max_batch_size = min_batch_size, max_batch_size
         self.inference_max_length = inference_max_length
         self.max_chunk_size_bytes = max_chunk_size_bytes
@@ -300,7 +300,7 @@ class Server:
         
         # Create configuration
         config = PruningConfig(
-            method=PruningMethod.ADAPTIVE_NEURAL,
+            method=PruningMethod.SIMPLE_PROBABILITY,
             neural_threshold=0.5,
             simple_threshold=0.1
         )


### PR DESCRIPTION
1. add batch support for speculative decoding. For different sample in a batch, padding tokens are used in inputs. 
2. add batch support for speculative decoding pruning. When transferring hidden states between different server, flatten batch samples into a single sequence. 