### PR TITLE
Default zstd level to 1 and allow BF16 byte_split

### DIFF
--- a/src/bloombee/utils/lossless_transport.py
+++ b/src/bloombee/utils/lossless_transport.py
@@ -148,9 +148,9 @@ def _lossless_algo() -> str:
 
 
 def _lossless_level() -> int:
-    cfg_val = _get_cfg("LOSSLESS_LEVEL", 3)
+    cfg_val = _get_cfg("LOSSLESS_LEVEL", 1)
     if _allow_env_override() and "BLOOMBEE_LOSSLESS_LEVEL" in os.environ:
-        return _get_env_int("BLOOMBEE_LOSSLESS_LEVEL", 3)
+        return _get_env_int("BLOOMBEE_LOSSLESS_LEVEL", 1)
     try:
         return int(cfg_val)
     except Exception:
@@ -1617,7 +1617,7 @@ def _supports_byte_split_layout(
         return False
     if tensor is None or not torch.is_tensor(tensor):
         return False
-    if tensor.dtype not in (torch.float16, torch.float32):
+    if tensor.dtype not in (torch.float16, torch.bfloat16, torch.float32):
         return False
     if raw_size != tensor.numel() * tensor.element_size():
         return False

--- a/src/bloombee/utils/lossless_wrapper_config.py
+++ b/src/bloombee/utils/lossless_wrapper_config.py
@@ -14,7 +14,7 @@ LOSSLESS_ALGO = "zstd"
 # Compression level:
 # - zstd: typically 1..22 (3 is a good low-latency default)
 # - zlib: -1..9
-LOSSLESS_LEVEL = 3
+LOSSLESS_LEVEL = 1
 
 # "plain" = compress the original serialized buffer as one stream
 # "byte_split" = also try splitting float16/float32 high-byte lanes into a second zstd stream


### PR DESCRIPTION
zstd L1 strictly dominates L3 on BF16 LLM activations after byte_split: the low byte is dominated by mantissa noise that L3 wastes hash-table searches on. L1 gets +2.6% wire ratio (1.43x -> 1.47x) AND -45% compress time (1.10ms -> 0.59ms per tensor) on captured Qwen3-14B hidden states.

Adding bfloat16 to _supports_byte_split_layout is required for the L1 win to take effect on BF16-native models (Qwen3, Llama-3); otherwise BF16 tensors fall through to plain zstd and miss byte_split entirely.

Compression remains opt-in via BLOOMBEE_LOSSLESS_WRAPPER (default 0).

## Summary

  Switch default `LOSSLESS_LEVEL` from `3` to `1`, and allow BF16 tensors through the `byte_split` layout.

  L1 strictly beats L3 on BF16 activations: higher ratio (1.43x -> 1.47x) **and** lower compress time (1.10ms -> 0.59ms per tensor). Compression remains opt-in via
  `BLOOMBEE_LOSSLESS_WRAPPER`.

## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code cleanup
  - [ ] Documentation update
  - [ ] CI / tooling change
  - [x] Other: performance default change



## Checklist

  - [ ] Code is formatted with `black` and `isort` (`pre-commit run --all-files`)
  - [x] No unrelated files are included in this PR
  - [ ] Relevant documentation is updated (README, CONTRIBUTING, docstrings)
