### PR TITLE
fix(server): restore @dataclass on S2SLinkTelemetry (S2S pushes broken on main)

### DIFF
--- a/src/bloombee/server/s2s_flow.py
+++ b/src/bloombee/server/s2s_flow.py
@@ -18,6 +18,7 @@ from typing import Deque, Optional
 from bloombee.utils.microbatch_config import MBPIPE_LOG_PREFIX
 
 
+@dataclass
 class S2SLinkTelemetry:
     """
     Rolling transport telemetry for one server-to-server link.


### PR DESCRIPTION
## Bug

PR #61 extracted `S2SLinkTelemetry` from `handler.py` into `server/s2s_flow.py` but dropped the `@dataclass` decorator. The class declares annotated fields (`label`, `window_size`, `field(init=False)` deques) with a `__post_init__`, so without the decorator it has only the default `object.__init__` and every instantiation raises:

```
TypeError: S2SLinkTelemetry() takes no arguments
```

`TransformerConnectionHandler._record_s2s_network_sample` instantiates it on the first S2S push of every link (`handler.py`), so **every server-to-server push on current main raises**, the client times out and enters 60s retry loops — distributed inference over multiple servers is effectively unusable on main right now.

## Repro (4×L4 host, vicuna-13b-v1.3 split 0:20/20:40 across two servers)

Plain autoregressive decode, batch 8, 32 new tokens:

- **main (0d4119b):** S1 log shows `P2PHandlerError: TypeError('S2SLinkTelemetry() takes no arguments')` on every push; client never completes (killed at 420 s timeout, no result).
- **main + this one-line fix:** same run completes cleanly — 256 tokens in 6.26 s (40.9 tok/s), 0 errors, 0 retries.

## Fix

Restore the `@dataclass` decorator (one line). `AdaptivePushConcurrency` in the same file has an explicit `__init__` and is unaffected.

## Validation

- `S2SLinkTelemetry(label='x', window_size=4)` + `.record(...)` instantiate and run.
- End-to-end 2-server swarm + client decode passes after the fix (see above).